### PR TITLE
Link frontpage newest episode -feature number and title to episode-page

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -68,17 +68,21 @@ const IndexPage = () => (
                     Uusin podcast-jakso
                   </h3>
                   <div className="newest-podcast">
-                    <h1 className="newest-podcast__number">
-                      {latestEpisode.number}
-                    </h1>
+                    <a href={`/${latestEpisode.number}`} className="newest-podcast__block-link">
+                      <h1 className="newest-podcast__number">
+                        {latestEpisode.number}
+                      </h1>
+                    </a>
 
                     <div className="newest-podcast__content">
-                      <h1 className="newest-podcast__title">
-                        <span className="newest-podcast__title-number">
-                          {latestEpisode.number}.{' '}
-                        </span>
-                        {episodeTitleWithoutNumber(latestEpisode.title)}
-                      </h1>
+                      <a href={`/${latestEpisode.number}`} className="newest-podcast__block-link">
+                        <h1 className="newest-podcast__title">
+                          <span className="newest-podcast__title-number">
+                            {latestEpisode.number}.{' '}
+                          </span>
+                          {episodeTitleWithoutNumber(latestEpisode.title)}
+                        </h1>
+                      </a>
 
                       <Meta
                         publishedAt={latestEpisode.publishedAt}

--- a/src/pages/index.scss
+++ b/src/pages/index.scss
@@ -52,6 +52,11 @@
   }
 }
 
+.newest-podcast__block-link {
+  color: inherit;
+  text-decoration: none;
+}
+
 .newest-podcast__number {
   position: relative;
   top: -14px;


### PR DESCRIPTION
Is there a reason the newest episode should be listened at the frontpage but include full details only at the episode page? If you start to listen at the frontpage and during the episode wan't to open the links accidentally might change to episode page and lost the current listening time.